### PR TITLE
Fix Travis Builds -- No Code Changes

### DIFF
--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -11,20 +11,20 @@
     <description>SDK for interacting with the LaunchKey distributed authentication and authorization platform</description>
     <packaging>jar</packaging>
     <properties>
-        <jacksonVersion>[2.4.0,3.0.0)</jacksonVersion>
+        <jacksonVersion>[2.0.0,2.999.999]</jacksonVersion>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>[4.3,5.0)</version>
+            <version>[4.3,4.999]</version>
         </dependency>
 
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>[1.7,2.0)</version>
+            <version>[1.7,1.999]</version>
         </dependency>
 
         <dependency>
@@ -42,19 +42,19 @@
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-            <version>[1.1.2,2.0.0)</version>
+            <version>[1.1.2,1.999.999]</version>
         </dependency>
 
         <dependency>
             <groupId>org.bitbucket.b_c</groupId>
             <artifactId>jose4j</artifactId>
-            <version>[0.5.1,1.0.0)</version>
+            <version>[0.5.1,0.999.999]</version>
         </dependency>
 
         <dependency>
             <groupId>javax.cache</groupId>
             <artifactId>cache-api</artifactId>
-            <version>[1.0.0,2.0.0)</version>
+            <version>[1.0.0,1.999.999]</version>
         </dependency>
 
 
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>[1.46,2.0)</version>
+            <version>[1.46,1.999]</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Update SDK POM dependecies version to not allow for snapshots of unwanted version

We had issues with [2.0.0,3.0.0), greater than or equal to 2.0.0 and less than 3.0.0 pulling in a development snapshot of 3.0.0-SNAPSHOT. It wopuld seem that this is unintended behavior but it was failing integration tests in Travis CI. So, now we will use the same method we use in Python. The range of [2.0.0, 2.999.999] will be used to have the intended effect.
Restrict jackson version to see if we can get tests to pass on travis