### PR TITLE
Fix some bug old and new.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ This changelog references the relevant changes (bug and security fixes) for the 
     * Added verification of webhook headers.
     * Added dynamic authorization request title
     * Added authorization response context
+    * Fix bug when attempting to retrieve and authorization response after an authorization request timed out. The transport
+      would throw a JWE exception when attempting to decrypt an unencrypted response rather than throwing the expected
+      AuthorizationRequestTimedOutError.
 
   * 4.2.1
 

--- a/sdk/src/main/java/com/iovation/launchkey/sdk/transport/apachehttp/ApacheHttpTransport.java
+++ b/sdk/src/main/java/com/iovation/launchkey/sdk/transport/apachehttp/ApacheHttpTransport.java
@@ -134,7 +134,7 @@ public class ApacheHttpTransport implements Transport {
 
         String path = "/service/v3/auths/" + authRequestId.toString();
         try {
-            httpResponse = getHttpResponse("GET", path, subject, null, true, Collections.singletonList(408));
+            httpResponse = getHttpResponse("GET", path, subject, null, true, null);
         } catch (RequestTimedOut e) {
             throw new AuthorizationRequestTimedOutError();
         }
@@ -719,13 +719,13 @@ public class ApacheHttpTransport implements Transport {
         final int statusCode = response.getStatusLine().getStatusCode();
         if (httpStatusCodeWhiteList.contains(statusCode)) {
             logger.debug("Did not throw for status as it was in white list");
-        } else if (statusCode == 400) {
+        } else if (statusCode == 400 || statusCode == 409) {
             final HttpEntity httpEntity = response.getEntity();
             if (httpEntity == null || httpEntity.getContentLength() == 0) {
                 throw new InvalidRequestException(
                         response.getStatusLine().getReasonPhrase(),
                         null,
-                        "HTTP-400"
+                        "HTTP-" + statusCode
                 );
             } else {
                 com.iovation.launchkey.sdk.transport.domain.Error error = decryptResponse(response, Error.class);
@@ -735,7 +735,6 @@ public class ApacheHttpTransport implements Transport {
             String message = "HTTP Error: [" + String.valueOf(statusCode)
                     + "] " + response.getStatusLine().getReasonPhrase();
             throw CommunicationErrorException.fromStatusCode(statusCode, message);
-
         }
     }
 


### PR DESCRIPTION
Fix bug when attempting to retrieve and authorization response after an authorization request timed out. The transport
      would throw a JWE exception when attempting to decrypt an unencrypted response rather than throwing the expected
      AuthorizationRequestTimedOutError.
Fix bug for busy signal not beng properly wired in the transport.