### PR TITLE
Fix null pointer exceptions in CLI example with legacy Auth SDK.

### DIFF
--- a/examples/cli-example/src/main/java/com/iovation/launchkey/sdk/example/cli/ServiceCommand.java
+++ b/examples/cli-example/src/main/java/com/iovation/launchkey/sdk/example/cli/ServiceCommand.java
@@ -122,11 +122,13 @@ class ServiceCommand {
     }
 
     private static String naForNull(Enum value) {
-        return naForNull(value.name());
+        String name = value == null ? null : value.name();
+        return naForNull(name);
     }
 
     private static String naForNull(Boolean value) {
-        return naForNull(value.toString());
+        String name = value == null ? null : value.toString();
+        return naForNull(name);
     }
 
     private static List<DenialReason> getDenialReasons(Integer fraud, Integer nonFraud)


### PR DESCRIPTION
Properly handle nulls in response parsing for service command.