### PR TITLE
Update error parsing to ignore unknown attributes.

### DIFF
--- a/sdk/src/main/java/com/iovation/launchkey/sdk/transport/domain/Error.java
+++ b/sdk/src/main/java/com/iovation/launchkey/sdk/transport/domain/Error.java
@@ -13,8 +13,10 @@
 package com.iovation.launchkey.sdk.transport.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Error {
     private final String errorCode;
     private final Object errorDetail;

--- a/sdk/src/test/java/com/iovation/launchkey/sdk/transport/domain/ErrorTest.java
+++ b/sdk/src/test/java/com/iovation/launchkey/sdk/transport/domain/ErrorTest.java
@@ -80,4 +80,12 @@ public class ErrorTest {
         assertEquals(true, data.get("my_auth"));
         assertEquals("2018-11-28T22:04:44Z", data.get("expires"));
     }
+
+    @Test
+    public void objectMapperIgnoresUnknown() throws Exception {
+        String json = "{\"error_code\":\"Error Code\",\"error_detail\":{\"one\":1,\"two\":2.0,\"three\":\"three\"},\"unknown\":null}";
+        Error error = mapper.readValue(json, Error.class);
+        assertNotNull(error.getErrorDetail());
+    }
+
 }


### PR DESCRIPTION
This is a port of the fix from 4.2.2.