### PR TITLE
Travis fixes

### DIFF
--- a/.travis.settings.xml
+++ b/.travis.settings.xml
@@ -20,7 +20,7 @@
                 <repository>
                     <id>central</id>
                     <name>Central Repository</name>
-                    <url>http://repo.maven.apache.org/maven2</url>
+                    <url>https://repo.maven.apache.org/maven2</url>
                     <releases>
                         <enabled>true</enabled>
                     </releases>

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,5 @@ jdk:
   - openjdk9
   - openjdk10
   - openjdk11
-  - oraclejdk11
   - openjdk12
-  - oraclejdk12
   - openjdk13
-  - oraclejdk13


### PR DESCRIPTION
* Fix Maven Central repository URL
* Remove OracleJDK from the matrix as OracleJDK is just an alias for OpenJDK now.