### PR TITLE
Update Jacoco Configuration

### DIFF
--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -46,12 +46,26 @@
                                     <goal>report</goal>
                                 </goals>
                             </execution>
-<!--                            <execution>-->
-<!--                                <id>check</id>-->
-<!--                                <goals>-->
-<!--                                    <goal>check</goal>-->
-<!--                                </goals>-->
-<!--                            </execution>-->
+                            <execution>
+                                <id>default-check</id>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <rule>
+                                            <element>BUNDLE</element>
+                                            <limits>
+                                                <limit>
+                                                    <counter>COMPLEXITY</counter>
+                                                    <value>COVEREDRATIO</value>
+                                                    <minimum>0.40</minimum>
+                                                </limit>
+                                            </limits>
+                                        </rule>
+                                    </rules>
+                                </configuration>
+                            </execution>
                         </executions>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
This fixes Jacoco build issues.

Jacoco now requires rule configuration for the `check` target. The reasoning for the `0.40` minimum is that, as far as I can tell, any class that has less than the minimum coverage will cause the check to fail. The class in our SDK with the least coverage has just over 40% coverage, so I've listed `0.40` as the minimum for now. This can be updated later, but for now, our builds should begin succeeding again.