### PR TITLE
Bump BouncyCastle FIPS to a minimum of 1.0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This changelog references the relevant changes (bug and security fixes) for the lifetime of the library.
 
+  * 4.10.0
+
+    * Bump the version of `bc-fips` in the unit test suite to a minimum of 1.0.2.1
+
   * 4.9.0
     
       * Updated JOSE Transport to include the SDK type and version in the User Agent Header

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -187,7 +187,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bc-fips</artifactId>
-            <version>[1.0.2,1.999]</version>
+            <version>[1.0.2.1,1.999]</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
### Summary
The version of `bc-fips` referenced in [this certificate ](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/2768) has been marked as `Historical`.

There is a [newer certificate](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/3514) for `bc-fips` that references v1.0.2.1, so I've updated the version of `bc-fips` within our test suite to be in line with this version so that we can be sure we are using a version that is in line with an active certificate.