### PR TITLE
Add single purpose key specific integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This changelog references the relevant changes (bug and security fixes) for the lifetime of the library.
 
+  * 4.10.0
+
+      * Allow for the management of single purpose keys
+
   * 4.9.0
     
       * Updated JOSE Transport to include the SDK type and version in the User Agent Header

--- a/integration/README.md
+++ b/integration/README.md
@@ -30,9 +30,10 @@ directory directly under the directory where this file is located.
 
 ### <a name="prerequisites"></a>Prerequisites
 
-In order to run the integration tests, a valid Organization with an active Public/Private Key Pair must exist. It is 
-suggested that you use a test organization that is separate from any Organizations you use in production. Creation of
-Organizations is managed by [Admin Center](https://admin.launchkey.com).
+In order to run the integration tests, a valid Organization must exist, and that Organization must have a 
+dual purpose key, an encryption key, and a signature key attached to it. It is suggested that you use a test 
+organization that is separate from any Organizations you use in production. Creation of Organizations is managed 
+by [Admin Center](https://admin.launchkey.com).
 
 ### <a name="run"></a>Run
   
@@ -41,13 +42,12 @@ values:
 
 * Required
     * `Launchkey.Organization.id` - Organization ID from Admin Center.
-    * `Launchkey.Organization.encryption_key` - File name of the PEM formatted RSA encryption private key of the 
-        Public/Private Key Pair of the Organization with the ID in the `Launchkey.Organization.id` property.
-    * `Launchkey.Organization.signature_key` - File name of the PEM formatted RSA signature private key of the
-        Public/Private Key Pair of the Organization with the ID in the `Launchkey.Organization.id` property.
-      
-**Note:** If you are using the same key for both encryption and decryption, the path for both
-`Launchkey.Organization.encryption_key` and `Launchkey.Organization.signature_key` should be the same.
+    * `Launchkey.Organization.dual_purpose_key` - File name of the PEM formatted RSA dual purpose private key
+        associated with the Organization supplied in the `Launchkey.Organization.id` property.
+    * `Launchkey.Organization.encryption_key` - File name of the PEM formatted RSA encryption private key
+        associated with the Organization supplied in the `Launchkey.Organization.id` property.
+    * `Launchkey.Organization.signature_key` - File name of the PEM formatted RSA signature private key
+        associated with the Organization supplied in the `Launchkey.Organization.id` property.
 
 * Optional
     * `Launchkey.API.base_url` - Base URL for the LaunchKey API. This will only be required if you are making changes
@@ -57,7 +57,9 @@ Example:
 ```
 java \
 -DLaunchkey.Organization.id=6ee17b28-bf8b-11e7-9b28-0469f8dc10a5 \
--DLaunchkey.Organization.private_key=/tmp/private-key.pem \
+-DLaunchkey.Organization.dual_purpose_key=/tmp/dual_purpose_key.pem \
+-DLaunchkey.Organization.encryption_key=/tmp/encryption_key.pem \
+-DLaunchkey.Organization.signature_key=/tmp/signature_key.pem \
 -jar target/sdk-integration-tests-4.6.0-SNAPSHOT-jar-with-dependencies.jar
 classpath:features \
 --glue classpath:com.iovation.launchkey.sdk.integration \
@@ -69,7 +71,9 @@ Example (With Emulator Based Device Tests):
  ```
  java \
  -DLaunchkey.Organization.id=6ee17b28-bf8b-11e7-9b28-0469f8dc10a5 \
- -DLaunchkey.Organization.private_key=/tmp/private-key.pem \
+ -DLaunchkey.Organization.dual_purpose_key=/tmp/dual_purpose_key.pem \
+ -DLaunchkey.Organization.encryption_key=/tmp/encryption_key.pem \
+ -DLaunchkey.Organization.signature_key=/tmp/signature_key.pem \
  -DAppium.url=https://localhost:4723/wd/hub \
  -jar sdk-integration-tests-4.5.0-SNAPSHOT-jar-with-dependencies.jar \
  classpath:features \
@@ -84,7 +88,9 @@ Example (With Kobiton Based Device Tests):
 ```
 java \
 -DLaunchkey.Organization.id=6ee17b28-bf8b-11e7-9b28-0469f8dc10a5 \
--DLaunchkey.Organization.private_key=/tmp/private-key.pem \
+-DLaunchkey.Organization.dual_purpose_key=/tmp/dual_purpose_key.pem \
+-DLaunchkey.Organization.encryption_key=/tmp/encryption_key.pem \
+-DLaunchkey.Organization.signature_key=/tmp/signature_key.pem \
 -DAppium.url=https://billy.jean:5e449dd9-2720-4767-babb-cf29eddecb94@api.kobiton.com/wd/hub \
 -DAppium.Kobiton.use_kobiton=true \
 -DAppium.Kobiton.auth=billy.jean:5e449dd9-2720-4767-babb-cf29eddecb94 \

--- a/integration/src/main/java/com/iovation/launchkey/sdk/integration/constants/Launchkey.java
+++ b/integration/src/main/java/com/iovation/launchkey/sdk/integration/constants/Launchkey.java
@@ -7,6 +7,7 @@ public final class Launchkey {
 
     public static final class Organization {
         public static final String id = "Launchkey.Organization.id";
+        public static final String dual_purpose_key = "Launchkey.Organization.dual_purpose_key";
         public static final String encryption_key = "Launchkey.Organization.encryption_key";
         public static final String signature_key = "Launchkey.Organization.signature_key";
     }

--- a/integration/src/main/java/com/iovation/launchkey/sdk/integration/steps/KeySteps.java
+++ b/integration/src/main/java/com/iovation/launchkey/sdk/integration/steps/KeySteps.java
@@ -1,0 +1,158 @@
+package com.iovation.launchkey.sdk.integration.steps;
+
+import com.iovation.launchkey.sdk.FactoryFactory;
+import com.iovation.launchkey.sdk.FactoryFactoryBuilder;
+import com.iovation.launchkey.sdk.client.OrganizationFactory;
+import com.iovation.launchkey.sdk.crypto.JCECrypto;
+import com.iovation.launchkey.sdk.integration.constants.Launchkey;
+import com.iovation.launchkey.sdk.integration.managers.DirectoryManager;
+import io.cucumber.guice.ScenarioScoped;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.When;
+import io.cucumber.java.en.Then;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+
+import javax.inject.Inject;
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.security.Provider;
+import java.security.interfaces.RSAPrivateKey;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.*;
+
+
+@ScenarioScoped
+public class KeySteps {
+    private final GenericSteps genericSteps;
+    private final FactoryFactory factoryFactory;
+    private final JCECrypto jceCrypto;
+    private final Provider provider;
+
+    private OrganizationFactory organizationFactory;
+
+    @Inject
+    public KeySteps(GenericSteps genericSteps) {
+        String baseUrl = System.getProperty(Launchkey.API.base_url);
+        this.genericSteps = genericSteps;
+        this.provider = new BouncyCastleProvider();
+        this.jceCrypto = new JCECrypto(provider);
+        this.factoryFactory = new FactoryFactoryBuilder()
+            .setAPIBaseURL(baseUrl)
+            .setJCEProvider(provider)
+            .setRequestExpireSeconds(1)
+            .build();
+    }
+
+    private RSAPrivateKey getPrivateKeyPEM(String typeOfKey) throws IOException {
+        String privateKeyFile = null;
+
+        if (typeOfKey.equals("encryption")) {
+            privateKeyFile = System.getProperty(Launchkey.Organization.encryption_key);
+        } else if (typeOfKey.equals("signature")) {
+            privateKeyFile = System.getProperty(Launchkey.Organization.signature_key);
+        }
+
+        assertThat(privateKeyFile, is(not(nullValue())));
+
+        String privateKey = readFile(privateKeyFile);
+
+        return jceCrypto.getRSAPrivateKeyFromPEM(provider, privateKey);
+    }
+
+    private String readFile(String fileName) throws IOException {
+        StringBuilder sb = new StringBuilder();
+
+        BufferedReader reader = new BufferedReader(new FileReader(fileName));
+        String line = reader.readLine();
+
+        while (line != null) {
+            sb.append(line);
+            sb.append("\n");
+            line = reader.readLine();
+        }
+
+        return sb.toString();
+    }
+
+    private String getOrganizationId() {
+        String organizationId = System.getProperty(Launchkey.Organization.id);
+
+        assertThat(organizationId, not(organizationId.isEmpty()));
+        assertThat(organizationId, not(nullValue()));
+
+        return organizationId;
+    }
+
+    @Given("^I am using single purpose keys$")
+    public void iAmUsingSinglePurposeKeys() throws Throwable {
+        String organizationId = this.getOrganizationId();
+
+        RSAPrivateKey encryptionKey = getPrivateKeyPEM("encryption");
+        String encryptionKeyFingerprint = jceCrypto.getRsaPublicKeyFingerprint(provider, encryptionKey);
+
+        RSAPrivateKey signatureKey = getPrivateKeyPEM("signature");
+        String signatureKeyFingerprint = jceCrypto.getRsaPublicKeyFingerprint(provider, signatureKey);
+
+        // Ensure that two separate keys are passed
+        assertThat(
+            "The encryption key and signature key must be different keys.",
+            encryptionKeyFingerprint, not(equalTo(signatureKeyFingerprint)));
+
+        Map<String, RSAPrivateKey> keys = new ConcurrentHashMap<>();
+        keys.put(encryptionKeyFingerprint, encryptionKey);
+        keys.put(signatureKeyFingerprint, signatureKey);
+
+        organizationFactory = factoryFactory.makeOrganizationFactory(organizationId, keys, signatureKeyFingerprint);
+    }
+
+    @Given("^I am using single purpose keys but I am using my encryption key to sign$")
+    public void iAmUsingSinglePurposeKeysWithOnlyEncryptionKeys() throws Throwable {
+        String organizationId = this.getOrganizationId();
+
+        RSAPrivateKey encryptionKey = getPrivateKeyPEM("encryption");
+        String encryptionKeyFingerprint = jceCrypto.getRsaPublicKeyFingerprint(provider, encryptionKey);
+
+        // Intentionally using encryption key to sign...
+        RSAPrivateKey signatureKey = getPrivateKeyPEM("encryption");
+        String signatureKeyFingerprint = jceCrypto.getRsaPublicKeyFingerprint(provider, signatureKey);
+
+        Map<String, RSAPrivateKey> keys = new ConcurrentHashMap<>();
+        keys.put(encryptionKeyFingerprint, encryptionKey);
+        keys.put(signatureKeyFingerprint, signatureKey);
+
+        organizationFactory = factoryFactory.makeOrganizationFactory(organizationId, keys, signatureKeyFingerprint);
+    }
+
+    @Given("^I am using single purpose keys but I only set my signature key$")
+    public void iAmUsingSinglePurposeKeysWithOnlyASignatureKey() throws Throwable {
+        String organizationId = this.getOrganizationId();
+
+        RSAPrivateKey signatureKey = getPrivateKeyPEM("signature");
+        String signatureKeyFingerprint = jceCrypto.getRsaPublicKeyFingerprint(provider, signatureKey);
+
+        Map<String, RSAPrivateKey> keys = new ConcurrentHashMap<>();
+        keys.put(signatureKeyFingerprint, signatureKey);
+
+        organizationFactory = factoryFactory.makeOrganizationFactory(organizationId, keys, signatureKeyFingerprint);
+    }
+
+    @When("^I perform an API call using single purpose keys$")
+    @When("^I attempt an API call using single purpose keys$")
+    public void iPerformAnApiCallWithSinglePurposeKeys() throws Throwable {
+        try {
+            DirectoryManager directoryManager = new DirectoryManager(organizationFactory);
+            directoryManager.createDirectory();
+        } catch (Exception e) {
+            genericSteps.setCurrentException(e);
+        }
+    }
+
+    @Then("^no valid key will be available to decrypt response$")
+    public void noValidKeyExistsToDecryptResponse() throws Throwable {
+        genericSteps.anExceptionIsThrown("CryptographyError");
+    }
+}

--- a/integration/src/main/java/com/iovation/launchkey/sdk/integration/steps/KeySteps.java
+++ b/integration/src/main/java/com/iovation/launchkey/sdk/integration/steps/KeySteps.java
@@ -116,15 +116,11 @@ public class KeySteps {
         RSAPrivateKey encryptionKey = getPrivateKeyPEM("encryption");
         String encryptionKeyFingerprint = jceCrypto.getRsaPublicKeyFingerprint(provider, encryptionKey);
 
-        // Intentionally using encryption key to sign...
-        RSAPrivateKey signatureKey = getPrivateKeyPEM("encryption");
-        String signatureKeyFingerprint = jceCrypto.getRsaPublicKeyFingerprint(provider, signatureKey);
-
         Map<String, RSAPrivateKey> keys = new ConcurrentHashMap<>();
         keys.put(encryptionKeyFingerprint, encryptionKey);
-        keys.put(signatureKeyFingerprint, signatureKey);
 
-        organizationFactory = factoryFactory.makeOrganizationFactory(organizationId, keys, signatureKeyFingerprint);
+        // Intentionally using encryption key to sign...
+        organizationFactory = factoryFactory.makeOrganizationFactory(organizationId, keys, encryptionKeyFingerprint);
     }
 
     @Given("^I am using single purpose keys but I only set my signature key$")

--- a/integration/src/main/resources/features/keys/single-purpose-keys.feature
+++ b/integration/src/main/resources/features/keys/single-purpose-keys.feature
@@ -1,0 +1,19 @@
+Feature: Factories can utilize single purpose keys
+  In order to communicate with the API
+  As a SDK
+  I can utilize single purpose keys
+
+  Scenario: Having both a configured encryption and signature key will work
+    Given I am using single purpose keys
+    When I perform an API call using single purpose keys
+    Then there are no errors
+
+  Scenario: Using encryption key to sign will get the appropriate error
+    Given I am using single purpose keys but I am using my encryption key to sign
+    When I attempt an API call using single purpose keys
+    Then an Unauthorized error occurs
+
+  Scenario: Using signature key with no encryption key handles appropriate error
+    Given I am using single purpose keys but I only set my signature key
+    When I attempt an API call using single purpose keys
+    Then no valid key will be available to decrypt response

--- a/sdk/src/main/java/com/iovation/launchkey/sdk/transport/apachehttp/ApacheHttpTransport.java
+++ b/sdk/src/main/java/com/iovation/launchkey/sdk/transport/apachehttp/ApacheHttpTransport.java
@@ -826,13 +826,18 @@ public class ApacheHttpTransport implements Transport {
         try {
 
             final String jwt = getJWT(response);
-            String expectedAudience;
-            if (response.getStatusLine().getStatusCode() == 401) {
-                expectedAudience = "public";
-            } else {
-                expectedAudience = issuer.toString();
-            }
-            final JWTClaims claims = validateJWT(expectedTokenId, jwt, expectedAudience);
+
+            // TODO: Determine how we want to deal with non-public audience from API when 401 occurs
+            // String expectedAudience;
+            // if (response.getStatusLine().getStatusCode() == 401) {
+            //     System.out.println("Made it where we expected");
+            //     expectedAudience = "public";
+            // } else {
+            //     expectedAudience = issuer.toString();
+            // }
+            // final JWTClaims claims = validateJWT(expectedTokenId, jwt, expectedAudience);
+
+            final JWTClaims claims = validateJWT(expectedTokenId, jwt, issuer.toString());
             HttpEntity entity = response.getEntity();
             ByteArrayOutputStream stream = new ByteArrayOutputStream();
             if (entity != null) entity.writeTo(stream);


### PR DESCRIPTION
### Summary

- Add single purpose key specific tests
- Require integration test suite to be provided a dual purpose key, an encryption key, and a signature key
- Ensure expected audience is not modified by transport